### PR TITLE
Reduce the risk of id clashes

### DIFF
--- a/layouts/shortcodes/chart.html
+++ b/layouts/shortcodes/chart.html
@@ -1,7 +1,8 @@
 {{ $w := default "100" (.Get 0) }}
 {{ $h := default "300" (.Get 1) }}
 {{ $r := ( .Inner | chomp) }}
-{{ $id := index (seq 999 | shuffle) 1 }}
+{{ $seed := "foo" }}
+{{ $id := delimit (shuffle (split (md5 $seed) "" )) "" }}
 
 <div style="width: {{ $w }}%;height: {{ $h }}px;margin: 0 auto">
     <canvas id="{{ $id }}"></canvas>


### PR DESCRIPTION
When rendering over 10 charts on a page, I got a periodic clash in the IDs.  This results in the wrong data being loaded into one chart and the other chart not to render.  I have patched this locally to use the logic:

1 . Get the md5 hash of the seed string (in this case, the inner content of the expandable)
2. Split that into an array
3. Shuffle the array
4. Convert the array back into a string 

This gives you a unique id like `584abfca542dc4dbc81eccfcd6e4fd8c`.  This is much less likely to clash (but not impossible).

I hope this is useful to someone else.